### PR TITLE
fixes #16 and moved Stamina Bar flash effect code

### DIFF
--- a/Source/Game/Player/PlayerController.cs
+++ b/Source/Game/Player/PlayerController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using FlaxEditor;
 using FlaxEngine;
@@ -17,8 +17,6 @@ public class PlayerController : Script
     public  CharacterController     Controller          { get; set; }
     public  AudioSource             SFX_Unavailable     { get; set; }
     public  UIControl               DEBUG_SPEED         { get; set; }
-    public  UIControl               StaminaBar          { get; set; }
-    public  Color                   StamDefaultColor    { get; set; }
     public  Collider                GroundCheck         { get; set; }
     public  LinearGravity           Gravity             { get; set; }   
     
@@ -116,16 +114,9 @@ public class PlayerController : Script
     private void JumpDispatch() {
         // When you can't jump: no stamina, not grounded, and not within coyote time
         if (StaminaManager.Stamina - StaminaManager.StaminaJumpConsumption <= 0 && !StateMachine.IsGrounded) {
-            //! TODO FOR TOMORROW: make this into a function within PlayerHUD 
-            // Play SFX and flash the stamina bar
-            StaminaBar.Get<ProgressBar>().BarColor = Color.Red;
-            
             SFX_Unavailable.Play();
-            
-            Task.Run(async () => {
-                await Task.Delay(100);
-                StaminaBar.Get<ProgressBar>().BarColor = StamDefaultColor;
-            });
+
+            HUD.Effect_Flash_ProgressBar(HUD.StaminaBarFlashColor, HUD.StaminaBarDefaultColor, HUD.StaminaBarFlashDuration);
             
             return;
         }
@@ -151,7 +142,6 @@ public class PlayerController : Script
     void GroundCheckEnter (Collision collision) { StateMachine.IsGrounded = true ; _GroundCheckCounter++; }
 
     void GroundCheckExit  (Collision collision) { 
-        if (_GroundCheckCounter ==0 ) StateMachine.IsGrounded = false;  
         _GroundCheckCounter--; 
         if (_GroundCheckCounter == 0 ) StateMachine.IsGrounded = false;  
     }

--- a/Source/Game/Player/PlayerHUD.cs
+++ b/Source/Game/Player/PlayerHUD.cs
@@ -1,4 +1,6 @@
-﻿using FlaxEngine;
+﻿using System;
+using System.Threading.Tasks;
+using FlaxEngine;
 using FlaxEngine.GUI;
 
 namespace Game;
@@ -9,17 +11,35 @@ namespace Game;
 public class PlayerHUD : Script
 {
     
-    public StaminaManager StaminaManager { get; set; }
+    public StaminaManager StaminaManager    { get; set; }
+    public  UIControl StaminaBar            { get; set; }
 
-    [Header("UI Elements")]
-    public  UIControl StaminaBar { get; set; }
+    
+    [Header("Stamina Bar")]
+    public  Color   StaminaBarDefaultColor  { get; set; }
+    public  Color   StaminaBarFlashColor    { get; set; } = Color.Red;
+    [ValueCategory(Utils.ValueCategory.Time)]
+    public  float   StaminaBarFlashDuration { get; set; } = 0.1f;
 
-    public override void OnStart() {}
+    public override void OnStart() {
+        
+        StaminaBarDefaultColor = StaminaBar.Get<ProgressBar>().BarColor;
+    
+    }
 
     /// <inheritdoc/>
-    public override void OnUpdate()
-    {
-        // Will include other UI elements like health, ammo, etc.
-        StaminaBar .Get<ProgressBar> ().Value    = StaminaManager.Stamina / StaminaManager.MaxStamina ;
+    public override void OnUpdate() {
+        StaminaBar.Get<ProgressBar>().Value = StaminaManager.Stamina / StaminaManager.MaxStamina ;
+    }
+
+    public void Effect_Flash_ProgressBar(Color ToColor, Color FromColor, float Duration) {
+        
+        StaminaBar.Get<ProgressBar>().BarColor = ToColor;
+        
+        Task.Run( async () => {
+            await Task.Delay(TimeSpan.FromSeconds(Duration));
+            StaminaBar.Get<ProgressBar>().BarColor = FromColor;
+        });
+        
     }
 }

--- a/Source/Game/Player/StaminaManager.cs
+++ b/Source/Game/Player/StaminaManager.cs
@@ -13,6 +13,7 @@ namespace Game;
 public class StaminaManager : Script{
     public PlayerStateMachine StateMachine      { get; set; }
     public PlayerController MovementController  { get; set; }
+    public PlayerInputSystem InputSystem        { get; set; }
 
     public float Stamina                        { get; set; }   = 100   ;
     public float MaxStamina                     { get; set; }   = 100   ;
@@ -29,7 +30,7 @@ public class StaminaManager : Script{
         if (!StateMachine.RegenningStamina)
             _ = RegenStamina();
 
-        StateMachine.CanAirStrafe = !StateMachine.IsGrounded && Stamina > 0;
+        StateMachine.CanAirStrafe = !StateMachine.IsGrounded && Stamina > 0 && InputSystem.MovementInput != Vector3.Zero;
 
         if (!StateMachine.CanAirStrafe) return;
 


### PR DESCRIPTION
fixes #16 by only deducting stamina if the player is moving through inputs (WASD or Jump)

And also moved the flashing effect for the stamina bar from `PlayerController` to `PlayerHUD` instead.