### PR TITLE
Speed is now reported for all 3 movement axis + Improved comments/documentation for how Stamina Calculations work.

### DIFF
--- a/Source/Game/Player/PlayerController.cs
+++ b/Source/Game/Player/PlayerController.cs
@@ -67,7 +67,7 @@ public class PlayerController : Script
         
 
         // * Update UI
-        DEBUG_SPEED.Get<Label>().Text     = "Speed: " + ( (int) CalculateSpeed() ).ToString() +
+        DEBUG_SPEED.Get<Label>().Text     = "Speed: " + ( (int) CalculateSpeed().Length ).ToString() +
                                             "\t FPS: " + Math.Round(1 / Time.DeltaTime).ToString();
         
     }
@@ -132,8 +132,8 @@ public class PlayerController : Script
         //! a proper jump system.
     }
 
-    float CalculateSpeed () {
-        float Speed = (Actor.Position - _PrevPosition).Length / Time.DeltaTime;
+    public Vector3 CalculateSpeed () {
+        Vector3 Speed = (Actor.Position - _PrevPosition) / Time.DeltaTime;
         _PrevPosition = Actor.Position;
         return Speed;
     }

--- a/Source/Game/Player/StaminaManager.cs
+++ b/Source/Game/Player/StaminaManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -34,12 +34,14 @@ public class StaminaManager : Script{
 
         if (!StateMachine.CanAirStrafe) return;
 
-        // This code manages the deduction of air strafes based on certain conditions:
+        // This code manages the deduction of air strafes based on certain conditions,
+        // 1) The player must not be grounded.
+        // 2) One or multiple of the following conditions must be met:
         // * If the player is jumping
         // * If the player is running (this increases the rate of air strafe consumption)
         // * If the player is moving (normal rate of air strafe consumption)
         // * If the player is grounded (no air strafes are consumed)
-        // The resulting air strafe count is clamped between 0 and AirStrafeMax.
+        // The resulting air strafe count is clamped between 1 and MaxStamina.
         StateMachine.UsingStamina = true;
         Stamina = Math.Clamp(
             // The base air strafe count is reduced by a consumption rate, which is modified by various factors.


### PR DESCRIPTION
* The `CalculateSpeed` function within the `PlayerController` script returns a `Vector3` instead of a `float`, meaning
you can now get the speed just for X, Y, or Z axis.

* The comment explaining how stamina is deducted felt confusing, now it makes it clear that the player must **NOT** be grounded at all for stamina to be consumed.