### PR TITLE
Patched minor stuttering when trying to jump

### DIFF
--- a/Source/Game/Player/PlayerController.cs
+++ b/Source/Game/Player/PlayerController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using FlaxEditor;
 using FlaxEngine;
@@ -129,7 +129,9 @@ public class PlayerController : Script
         bool CanJump = StaminaManager.Stamina - StaminaManager.StaminaJumpConsumption > 0 || StateMachine.IsGrounded;
         // When you can't jump: no stamina or not grounded
         if (!CanJump) {
-            SFX_Unavailable.Play();
+            // TODO: Add sound effect
+
+            // SFX_Unavailable.Play();
             HUD.Effect_Flash_ProgressBar(HUD.StaminaBarFlashColor, HUD.StaminaBarDefaultColor, HUD.StaminaBarFlashDuration);
             return;
         } 


### PR DESCRIPTION
commented out SFX playback for insufficient stamina.

Reason: Minor stuttering can occur because no sound clip has been assigned.